### PR TITLE
Add API permissions and JWT and Keycloak authorization modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Command line options:
     Usage: java outbackcdx.Server [options...]
     
 
-      -a url        Use a wayback access control oracle
-      -b bindaddr   Bind to a particular IP address
-      -d datadir    Directory to store index data under
-      -i            Inherit the server socket via STDIN (for use with systemd, inetd etc)
-      -p port       Local port to listen on
-      -t count      Number of web server threads
-      -v            Verbose logging
+      -a url                Use a wayback access control oracle
+      -b bindaddr           Bind to a particular IP address
+      -d datadir            Directory to store index data under
+      -i                    Inherit the server socket via STDIN (for use with systemd, inetd etc)
+      -j jwks-url perm-path Enable JWT-based authorization
+      -p port               Local port to listen on
+      -t count              Number of web server threads
+      -v                    Verbose logging
 
 The server supports multiple named indexes as subdirectories.  Currently indexes
 are created automatically when you first write records to them.
@@ -215,3 +216,28 @@ Aliases do not currently work with url prefix queries. Aliases are resolved afte
 are applied.
 
 Aliases can be mixed with regular CDX lines either in the same file or separate files and in any order. Any existing records that the alias rule affects the canonicalised URL for will be updated when the alias is added to the index.
+
+JWT-based Authorization
+-----------------------
+
+Authorization to modify the index and access control rules can be controlled using [JSON Web Tokens](https://jwt.io/).
+To enable this you will typically use some sort of separate authentication server to sign the JWTs. We use
+[KeyCloak](https://www.keycloak.org/) but other auth servers supporting JWT should theoretically also work.
+
+OutbackCDX's `-j` option takes two arguments, a JWKS URL for the public key of the auth server and a slash-delimited
+path for where to find the list of permissions in the JWT received as a HTTP bearer token.
+
+### KeyCloak setup
+
+1. In KeyCloak's dashboard create a new client for OutbackCDX with the protocol `openid-connect`.
+2. Under the client's roles tab create the following roles:
+    * index_edit
+    * rules_edit
+    * policies_edit
+3. Map your users or service accounts to these client roles as appropriate.
+4. Run OutbackCDX with this option:
+
+```
+-j https://{keycloak-server}/auth/realms/{realm}/protocol/openid-connect/certs
+   resource_access/{client-id}/roles
+```

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,11 @@
             <artifactId>urlcanon</artifactId>
             <version>0.1.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>6.0</version>
+        </dependency>
         <!--
           JavaScript for dashboard
         -->

--- a/resources/outbackcdx/dashboard.html
+++ b/resources/outbackcdx/dashboard.html
@@ -47,7 +47,25 @@
             left: 0;
             right: 0;
             height: 24px;
+            color: #ffffffb2;
         }
+
+        .status-bar a {
+            color: #fff;
+            text-decoration: none;
+            font-weight: bold;
+            opacity: 0.7;
+        }
+
+        .status-bar a:hover {
+            opacity: 1;
+        }
+
+        .account-link {
+            float: right;
+            margin-right: 72px;
+        }
+
         .bg-top{
             height: 96px;
             background: #FE7119;
@@ -74,7 +92,6 @@
             margin-top: 8px;
             margin-bottom: -6px;
         }
-
 
         .app-bar {
             position: absolute;
@@ -294,14 +311,23 @@
     <script src="lib/pikaday/1.4.0/pikaday.js"></script>
     <script src="api.js"></script>
     <script>
+        var keycloak = null;
+
+        function fetchApi(url, options={}) {
+            if (keycloak && keycloak.token) {
+                options.headers = {'Authorization': 'bearer ' + keycloak.token};
+            }
+            return fetch(url, options);
+        }
+
         function urlTemplate(template, pathParams, queryParams) {
             var path = template;
-            for (var key in pathParams) {
+            for (let key in pathParams) {
                 path = path.replace('{' + key + '}', encodeURIComponent(pathParams[key]));
             }
             var qs = "";
             if (queryParams) {
-                for (var key in queryParams) {
+                for (let key in queryParams) {
                     if (queryParams[key]) {
                         qs += qs ? "&" : "?";
                         qs += encodeURIComponent(key) + "=" + encodeURIComponent(queryParams[key]);
@@ -309,6 +335,28 @@
                 }
             }
             return path + qs;
+        }
+
+        function loadScript(url, success) {
+            var script = document.createElement('script');
+            script.onload = success;
+            script.src = url;
+            document.head.appendChild(script);
+        }
+
+        function initKeycloak(app, keycloakConfig) {
+            loadScript(keycloakConfig.url + "/js/keycloak.js", () => {
+                keycloak = Keycloak(keycloakConfig);
+                keycloak.init({checkLoginIframe: false, onLoad: 'login-required'}).success(authenticated => {
+                    console.log(authenticated ? 'authenticated' : 'not authenticated');
+                    if (authenticated) {
+                        app.user = {
+                            name: keycloak.tokenParsed.name,
+                            accountUrl: keycloak.createAccountUrl()
+                        };
+                    }
+                }).error(() => alert('failed to initialize Keycloak'));
+            });
         }
     </script>
 </head>
@@ -364,7 +412,7 @@
                     fl: this.fields.join(","),
                     output: 'json'
                 };
-                fetch(urlTemplate("/{collection}", this.$route.params, query))
+                fetchApi(urlTemplate("/{collection}", this.$route.params, query))
                         .then(r => r.json())
                         .then(rows => this.rows = rows ? rows.slice(1) : []);
             }, 250),
@@ -553,7 +601,7 @@
             },
             save: function () {
                 this.rule.urlPatterns = this.rule.urlPatterns.filter(function(pattern) { return pattern != ""; });
-                fetch(urlTemplate("/{collection}/access/rules", this.$route.params),
+                fetchApi(urlTemplate("/{collection}/access/rules", this.$route.params),
                         {method: 'POST',
                         headers: {'Content-Type': 'application/json'},
                         body: JSON.stringify(this.rule)})
@@ -589,14 +637,14 @@
                 });
             },
             deleteRule: function () {
-                fetch(urlTemplate("/{collection}/access/rules/{ruleId}", this.$route.params), {method: 'DELETE'})
+                fetchApi(urlTemplate("/{collection}/access/rules/{ruleId}", this.$route.params), {method: 'DELETE'})
                         .then(() => this.cancel());
             },
             fetchData: function () {
                 // load in parallel but policy list must be populated first
                 Promise.all([
-                    fetch(urlTemplate("{collection}/access/policies", this.$route.params)).then(r => r.json()),
-                    fetch(urlTemplate("{collection}/access/rules/{ruleId}", this.$route.params)).then(r => r.json())
+                    fetchApi(urlTemplate("{collection}/access/policies", this.$route.params)).then(r => r.json()),
+                    fetchApi(urlTemplate("{collection}/access/rules/{ruleId}", this.$route.params)).then(r => r.json())
                 ]).then(([policies, rule]) => {
                     this.policies = policies;
                     // the objects need to be present for the model binding
@@ -700,8 +748,8 @@
             },
             fetchData: _.throttle(function() {
                 Promise.all([
-                    fetch(urlTemplate('{collection}/access/policies', this.$route.params)).then(r => r.json()),
-                    fetch(urlTemplate('{collection}/access/rules', this.$route.params, this.$route.query)).then(r => r.json())
+                    fetchApi(urlTemplate('{collection}/access/policies', this.$route.params)).then(r => r.json()),
+                    fetchApi(urlTemplate('{collection}/access/rules', this.$route.params, this.$route.query)).then(r => r.json())
                 ]).then(([policies, rules]) => {
                     policies.forEach(policy => this.policyNames[policy.id] = policy.name);
                     this.rules = rules;
@@ -746,7 +794,7 @@
         },
         methods: {
             fetchData: _.throttle(function() {
-                fetch(urlTemplate('{collection}/access/policies', this.$route.params,
+                fetchApi(urlTemplate('{collection}/access/policies', this.$route.params,
                         this.$route.query)).then(r => r.json())
                         .then(policies => this.policies = policies);
             }, 250)
@@ -760,6 +808,9 @@
 ------------------------------------------------------------------------->
 <div id="app" class="row">
     <div class="status-bar">
+        <div v-if="user" class="account-link">
+            <a :href="user.accountUrl">{{user.name}}</a>
+        </div>
     </div>
     <div class="bg-top">
         <img src="outback.svg" width="55px" height="54px" class="logo">
@@ -808,13 +859,19 @@
             collection: null,
             collections: {},
             stats: null,
-            featureFlags: {}
+            featureFlags: {},
+            user: null,
         },
         created: function() {
             var self = this;
-            fetch("api/featureflags").then(r => r.json())
-                    .then(featureFlags => this.featureFlags = featureFlags);
-            fetch("api/collections").then(r => r.json()).then(collections => {
+            fetchApi("config.json").then(r => r.json())
+                    .then(config => {
+                        this.featureFlags = config.featureFlags;
+                        if (config.keycloak) {
+                            initKeycloak(app, config.keycloak);
+                        }
+                    });
+            fetchApi("api/collections").then(r => r.json()).then(collections => {
                 this.collections = collections;
                 if (collections && !self.activeCollection) {
                     self.activeCollection = collections[0];

--- a/src/outbackcdx/Main.java
+++ b/src/outbackcdx/Main.java
@@ -1,9 +1,15 @@
 package outbackcdx;
 
+import outbackcdx.auth.Authorizer;
+import outbackcdx.auth.JwtAuthorizer;
+import outbackcdx.auth.NullAuthorizer;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.ServerSocket;
+import java.net.URL;
 import java.nio.channels.Channel;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.Executor;
@@ -15,12 +21,13 @@ public class Main {
     public static void usage() {
         System.err.println("Usage: java " + Main.class.getName() + " [options...]");
         System.err.println("");
-        System.err.println("  -b bindaddr   Bind to a particular IP address");
-        System.err.println("  -d datadir    Directory to store index data under");
-        System.err.println("  -i            Inherit the server socket via STDIN (for use with systemd, inetd etc)");
-        System.err.println("  -p port       Local port to listen on");
-        System.err.println("  -t count      Number of web server threads");
-        System.err.println("  -v            Verbose logging");
+        System.err.println("  -b bindaddr           Bind to a particular IP address");
+        System.err.println("  -d datadir            Directory to store index data under");
+        System.err.println("  -i                    Inherit the server socket via STDIN (for use with systemd, inetd etc)");
+        System.err.println("  -j jwks-url perm-path Enable JWT authorization");
+        System.err.println("  -p port               Local port to listen on");
+        System.err.println("  -t count              Number of web server threads");
+        System.err.println("  -v                    Verbose logging");
         System.exit(1);
     }
 
@@ -31,7 +38,7 @@ public class Main {
         boolean inheritSocket = false;
         File dataPath = new File("data");
         boolean verbose = false;
-        Predicate<Capture> filter = null;
+        Authorizer authorizer = new NullAuthorizer();
 
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
@@ -41,11 +48,19 @@ public class Main {
                 case "-b":
                     host = args[++i];
                     break;
+                case "-d":
+                    dataPath = new File(args[++i]);
+                    break;
                 case "-i":
                     inheritSocket = true;
                     break;
-                case "-d":
-                    dataPath = new File(args[++i]);
+                case "-j":
+                    try {
+                        authorizer = new JwtAuthorizer(new URL(args[++i]), args[++i]);
+                    } catch (MalformedURLException e) {
+                        System.err.println("Malformed JWKS URL in -j option");
+                        System.exit(1);
+                    }
                     break;
                 case "-v":
                     verbose = true;
@@ -60,7 +75,7 @@ public class Main {
         }
 
         try (DataStore dataStore = new DataStore(dataPath)) {
-            Webapp controller = new Webapp(dataStore, verbose);
+            Webapp controller = new Webapp(dataStore, verbose, authorizer);
             ServerSocket socket = openSocket(host, port, inheritSocket);
             Web.Server server = new Web.Server(socket, controller);
             ExecutorService threadPool = Executors.newFixedThreadPool(webThreads);
@@ -83,7 +98,7 @@ public class Main {
 
     private static ServerSocket openSocket(String host, int port, boolean inheritSocket) throws IOException {
         ServerSocket socket;Channel channel = System.inheritedChannel();
-        if (inheritSocket && channel != null && channel instanceof ServerSocketChannel) {
+        if (inheritSocket && channel instanceof ServerSocketChannel) {
             socket = ((ServerSocketChannel) channel).socket();
         } else {
             socket = new ServerSocket(port, -1, InetAddress.getByName(host));

--- a/src/outbackcdx/Web.java
+++ b/src/outbackcdx/Web.java
@@ -89,7 +89,7 @@ class Web {
     }
 
     static Response forbidden(String permission) {
-        return new Response(FORBIDDEN, "text/plain", "Permission '\" + permission + \"' is required for this action.\n");
+        return new Response(FORBIDDEN, "text/plain", "Permission '" + permission + "' is required for this action.\n");
     }
 
     static Response badRequest(String message) {

--- a/src/outbackcdx/Web.java
+++ b/src/outbackcdx/Web.java
@@ -3,11 +3,15 @@ package outbackcdx;
 import outbackcdx.NanoHTTPD.IHTTPSession;
 import outbackcdx.NanoHTTPD.Method;
 import outbackcdx.NanoHTTPD.Response;
+import outbackcdx.auth.Authorizer;
+import outbackcdx.auth.NullAuthorizer;
+import outbackcdx.auth.Permission;
 
 import java.net.ServerSocket;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,17 +88,37 @@ class Web {
         return new Response(NOT_FOUND, "text/plain", "Not found\n");
     }
 
+    static Response forbidden(String permission) {
+        return new Response(FORBIDDEN, "text/plain", "Permission '\" + permission + \"' is required for this action.\n");
+    }
+
     static Response badRequest(String message) {
         return new Response(BAD_REQUEST, "text/plain", message);
     }
 
     static class Router implements Handler {
-        private final List<Handler> routes = new ArrayList<>();
+        private final Authorizer authorizer;
+        private final List<Route> routes = new ArrayList<>();
+
+        public Router(Authorizer authorizer) {
+            this.authorizer = authorizer;
+        }
 
         @Override
         public Response handle(IHTTPSession request) throws Exception {
-            for (Handler route : routes) {
-                Response result = route.handle(request);
+            String authnHeader = request.getHeaders().getOrDefault("authorization", "");
+            Set<Permission> permissions = authorizer.verify(authnHeader);
+
+            for (Route route : routes) {
+                if (!route.matches(request)) {
+                    continue;
+                }
+
+                if (route.permission != null && !permissions.contains(route.permission)) {
+                    return Web.forbidden(route.permission.name().toLowerCase());
+                }
+
+                Response result = route.handler.handle(request);
                 if (result != null) {
                     return result;
                 }
@@ -102,13 +126,17 @@ class Web {
             return Web.notFound();
         }
 
-        public Router on(Method method, String pathPattern, Handler handler) {
-            routes.add(new Route(method, pathPattern, handler));
+        public Router on(Method method, String pathPattern, Handler handler, Permission permission) {
+            routes.add(new Route(method, pathPattern, handler, permission));
             return this;
+        }
+
+        public Router on(Method method, String pathPattern, Handler handler) {
+            return on(method, pathPattern, handler, null);
         }
     }
 
-    private static class Route implements Handler {
+    private static class Route {
         private final static Pattern KEY_PATTERN = Pattern.compile("<([a-z_][a-zA-Z0-9_]*)(?::([^>]*))?>");
 
         private final Method method;
@@ -116,26 +144,27 @@ class Web {
         private final String pattern;
         private final Pattern re;
         private final List<String> keys = new ArrayList<>();
+        private final Permission permission;
 
-        Route(Method method, String pattern, Handler handler) {
+        Route(Method method, String pattern, Handler handler, Permission permission) {
             this.method = method;
             this.handler = handler;
             this.pattern = pattern;
+            this.permission = permission;
             this.re = compile();
         }
 
-        @Override
-        public Response handle(IHTTPSession request) throws Exception {
+        public boolean matches(IHTTPSession request) throws Exception {
             if (method == null || method == request.getMethod()) {
                 Matcher m = re.matcher(request.getUri());
                 if (m.matches()) {
                     for (int i = 0; i < m.groupCount(); i++) {
                         request.getParms().put(keys.get(i), m.group(i + 1));
                     }
-                    return handler.handle(request);
+                    return true;
                 }
             }
-            return null;
+            return false;
         }
 
         private Pattern compile() {

--- a/src/outbackcdx/Webapp.java
+++ b/src/outbackcdx/Webapp.java
@@ -29,10 +29,11 @@ import static outbackcdx.Web.*;
 class Webapp implements Web.Handler {
     private final boolean verbose;
     private final DataStore dataStore;
-    final Web.Router router;
+    private final Web.Router router;
+    private final Map<String,Object> dashboardConfig;
 
-    private Response featureFlags(IHTTPSession req) {
-        return jsonResponse(FeatureFlags.asMap());
+    private Response configJson(IHTTPSession req) {
+        return jsonResponse(dashboardConfig);
     }
 
     private Response listAccessPolicies(IHTTPSession req) throws IOException, Web.ResponseException {
@@ -45,48 +46,47 @@ class Webapp implements Web.Handler {
         return found ? ok() : notFound();
     }
 
-    Webapp(DataStore dataStore, boolean verbose, Authorizer authorizer) {
+    Webapp(DataStore dataStore, boolean verbose, Authorizer authorizer, Map<String, Object> dashboardConfig) {
         this.dataStore = dataStore;
         this.verbose = verbose;
+        this.dashboardConfig = dashboardConfig;
 
-        router = new Router(authorizer)
-                .on(GET, "/", serve("dashboard.html"))
-                .on(GET, "/api", serve("api.html"))
-                .on(GET, "/api.js", serve("api.js"))
-                .on(GET, "/add.svg", serve("add.svg"))
-                .on(GET, "/database.svg", serve("database.svg"))
-                .on(GET, "/outback.svg",  serve("outback.svg"))
-                .on(GET, "/favicon.ico",  serve("outback.svg"))
-                .on(GET, "/swagger.json", serve("swagger.json"))
-
-                .on(GET, "/lib/vue-router/2.0.0/vue-router.js", serve("lib/vue-router/2.0.0/vue-router.js"))
-                .on(GET, "/lib/vue/2.0.1/vue.js", serve("/META-INF/resources/webjars/vue/2.0.1/dist/vue.js"))
-                .on(GET, "/lib/lodash/4.15.0/lodash.min.js", serve("/META-INF/resources/webjars/lodash/4.15.0/lodash.min.js"))
-                .on(GET, "/lib/moment/2.15.2/moment.min.js", serve("/META-INF/resources/webjars/moment/2.15.2/min/moment.min.js"))
-                .on(GET, "/lib/pikaday/1.4.0/pikaday.js", serve("/META-INF/resources/webjars/pikaday/1.4.0/pikaday.js"))
-                .on(GET, "/lib/pikaday/1.4.0/pikaday.css", serve("/META-INF/resources/webjars/pikaday/1.4.0/css/pikaday.css"))
-                .on(GET, "/lib/redoc/1.4.1/redoc.min.js", serve("/META-INF/resources/webjars/redoc/1.4.1/dist/redoc.min.js"))
-
-                .on(GET, "/api/collections", this::listCollections)
-                .on(GET, "/api/featureflags", this::featureFlags)
-                .on(GET, "/<collection>", this::query)
-                .on(POST, "/<collection>", this::post, Permission.INDEX_EDIT)
-                .on(GET, "/<collection>/stats", this::stats)
-                .on(GET, "/<collection>/captures", this::captures)
-                .on(GET, "/<collection>/aliases", this::aliases);
+        router = new Router(authorizer);
+        router.on(GET, "/", serve("dashboard.html"));
+        router.on(GET, "/api", serve("api.html"));
+        router.on(GET, "/api.js", serve("api.js"));
+        router.on(GET, "/add.svg", serve("add.svg"));
+        router.on(GET, "/database.svg", serve("database.svg"));
+        router.on(GET, "/outback.svg", serve("outback.svg"));
+        router.on(GET, "/favicon.ico", serve("outback.svg"));
+        router.on(GET, "/swagger.json", serve("swagger.json"));
+        router.on(GET, "/lib/vue-router/2.0.0/vue-router.js", serve("lib/vue-router/2.0.0/vue-router.js"));
+        router.on(GET, "/lib/vue/2.0.1/vue.js", serve("/META-INF/resources/webjars/vue/2.0.1/dist/vue.js"));
+        router.on(GET, "/lib/lodash/4.15.0/lodash.min.js", serve("/META-INF/resources/webjars/lodash/4.15.0/lodash.min.js"));
+        router.on(GET, "/lib/moment/2.15.2/moment.min.js", serve("/META-INF/resources/webjars/moment/2.15.2/min/moment.min.js"));
+        router.on(GET, "/lib/pikaday/1.4.0/pikaday.js", serve("/META-INF/resources/webjars/pikaday/1.4.0/pikaday.js"));
+        router.on(GET, "/lib/pikaday/1.4.0/pikaday.css", serve("/META-INF/resources/webjars/pikaday/1.4.0/css/pikaday.css"));
+        router.on(GET, "/lib/redoc/1.4.1/redoc.min.js", serve("/META-INF/resources/webjars/redoc/1.4.1/dist/redoc.min.js"));
+        router.on(GET, "/api/collections", this::listCollections);
+        router.on(GET, "/config.json", this::configJson);
+        router.on(GET, "/<collection>", this::query);
+        router.on(POST, "/<collection>", this::post, Permission.INDEX_EDIT);
+        router.on(GET, "/<collection>/stats", this::stats);
+        router.on(GET, "/<collection>/captures", this::captures);
+        router.on(GET, "/<collection>/aliases", this::aliases);
 
         if (FeatureFlags.experimentalAccessControl()) {
-            router.on(GET, "/<collection>/ap/<accesspoint>", this::query)
-                    .on(GET, "/<collection>/ap/<accesspoint>/check", this::checkAccess)
-                    .on(POST, "/<collection>/ap/<accesspoint>/check", this::checkAccessBulk)
-                    .on(GET, "/<collection>/access/rules", this::listAccessRules)
-                    .on(POST, "/<collection>/access/rules", this::postAccessRules, Permission.RULES_EDIT)
-                    .on(GET, "/<collection>/access/rules/new", this::getNewAccessRule, Permission.RULES_EDIT)
-                    .on(GET, "/<collection>/access/rules/<ruleId>", this::getAccessRule)
-                    .on(DELETE, "/<collection>/access/rules/<ruleId>", this::deleteAccessRule, Permission.RULES_EDIT)
-                    .on(GET, "/<collection>/access/policies", this::listAccessPolicies)
-                    .on(POST, "/<collection>/access/policies", this::postAccessPolicy, Permission.POLICIES_EDIT)
-                    .on(GET, "/<collection>/access/policies/<policyId>", this::getAccessPolicy);
+            router.on(GET, "/<collection>/ap/<accesspoint>", this::query);
+            router.on(GET, "/<collection>/ap/<accesspoint>/check", this::checkAccess);
+            router.on(POST, "/<collection>/ap/<accesspoint>/check", this::checkAccessBulk);
+            router.on(GET, "/<collection>/access/rules", this::listAccessRules);
+            router.on(POST, "/<collection>/access/rules", this::postAccessRules, Permission.RULES_EDIT);
+            router.on(GET, "/<collection>/access/rules/new", this::getNewAccessRule, Permission.RULES_EDIT);
+            router.on(GET, "/<collection>/access/rules/<ruleId>", this::getAccessRule);
+            router.on(DELETE, "/<collection>/access/rules/<ruleId>", this::deleteAccessRule, Permission.RULES_EDIT);
+            router.on(GET, "/<collection>/access/policies", this::listAccessPolicies);
+            router.on(POST, "/<collection>/access/policies", this::postAccessPolicy, Permission.POLICIES_EDIT);
+            router.on(GET, "/<collection>/access/policies/<policyId>", this::getAccessPolicy);
         }
     }
 

--- a/src/outbackcdx/auth/AuthException.java
+++ b/src/outbackcdx/auth/AuthException.java
@@ -1,0 +1,11 @@
+package outbackcdx.auth;
+
+public class AuthException extends Exception {
+    public AuthException(String message, Exception cause) {
+        super(message, cause);
+    }
+
+    public AuthException(String message) {
+        super(message);
+    }
+}

--- a/src/outbackcdx/auth/Authorizer.java
+++ b/src/outbackcdx/auth/Authorizer.java
@@ -1,0 +1,9 @@
+package outbackcdx.auth;
+
+import outbackcdx.NanoHTTPD;
+
+import java.util.Set;
+
+public interface Authorizer {
+    Set<Permission> verify(String authzHeader) throws AuthException;
+}

--- a/src/outbackcdx/auth/Authorizer.java
+++ b/src/outbackcdx/auth/Authorizer.java
@@ -1,7 +1,5 @@
 package outbackcdx.auth;
 
-import outbackcdx.NanoHTTPD;
-
 import java.util.Set;
 
 public interface Authorizer {

--- a/src/outbackcdx/auth/JwtAuthorizer.java
+++ b/src/outbackcdx/auth/JwtAuthorizer.java
@@ -1,0 +1,70 @@
+package outbackcdx.auth;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.*;
+
+public class JwtAuthorizer implements Authorizer {
+    private final String permsPath;
+    private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+
+    public JwtAuthorizer(URL jwksUrl, String permsPath) throws MalformedURLException {
+        this(new RemoteJWKSet<>(jwksUrl), permsPath);
+    }
+
+    JwtAuthorizer(JWKSource<SecurityContext> jwkSource, String permsPath) {
+        this.permsPath = permsPath;
+        jwtProcessor.setJWSKeySelector(new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, jwkSource));
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<String> lookup(Map<String,Object> nestedMap, String path) throws AuthException {
+        Object value = nestedMap;
+        for (String segment: path.split("/")) {
+            value = ((Map<String, Object>) value).get(segment);
+            if (value == null) {
+                throw new AuthException("Claim path " + path + " not found in access token");
+            }
+        }
+        return (List<String>) value;
+    }
+
+    @Override
+    public Set<Permission> verify(String authzHeader) throws AuthException {
+        try {
+            if (!authzHeader.regionMatches(true, 0, "bearer ", 0, "bearer ".length())) {
+                return Collections.emptySet();
+            }
+
+            String token = authzHeader.substring("bearer ".length());
+            JWTClaimsSet claimsSet = jwtProcessor.process(token, null);
+            List<String> roles = lookup(claimsSet.getClaims(), permsPath);
+
+            EnumSet<Permission> permissions = EnumSet.noneOf(Permission.class);
+            for (String role : roles) {
+                Permission permission;
+                try {
+                    permission = Permission.valueOf(role.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    continue; // ignore unknown permissions I guess
+                }
+                permissions.add(permission);
+            }
+            return permissions;
+        } catch (ParseException | BadJOSEException | JOSEException e) {
+            throw new AuthException("Invalid acccess token: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/outbackcdx/auth/JwtAuthorizer.java
+++ b/src/outbackcdx/auth/JwtAuthorizer.java
@@ -64,6 +64,7 @@ public class JwtAuthorizer implements Authorizer {
             }
             return permissions;
         } catch (ParseException | BadJOSEException | JOSEException e) {
+            e.printStackTrace();
             throw new AuthException("Invalid acccess token: " + e.getMessage(), e);
         }
     }

--- a/src/outbackcdx/auth/KeycloakConfig.java
+++ b/src/outbackcdx/auth/KeycloakConfig.java
@@ -1,0 +1,38 @@
+package outbackcdx.auth;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class KeycloakConfig {
+    private final String url;
+    private final String realm;
+    private final String clientId;
+
+    public KeycloakConfig(String url, String realm, String clientId) {
+        this.url = url;
+        this.realm = realm;
+        this.clientId = clientId;
+    }
+
+    public Authorizer toAuthorizer() {
+        try {
+            URL certsUrl = new URL(url + "/realms/" + realm + "/protocol/openid-connect/certs");
+            String permsPath = "resource_access/" + clientId + "/roles";
+            return new JwtAuthorizer(certsUrl, permsPath);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/src/outbackcdx/auth/NullAuthorizer.java
+++ b/src/outbackcdx/auth/NullAuthorizer.java
@@ -1,0 +1,13 @@
+package outbackcdx.auth;
+
+import outbackcdx.NanoHTTPD;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class NullAuthorizer implements Authorizer {
+    @Override
+    public Set<Permission> verify(String authzHeader) {
+        return EnumSet.allOf(Permission.class);
+    }
+}

--- a/src/outbackcdx/auth/Permission.java
+++ b/src/outbackcdx/auth/Permission.java
@@ -1,0 +1,7 @@
+package outbackcdx.auth;
+
+public enum Permission {
+    INDEX_EDIT,
+    RULES_EDIT,
+    POLICIES_EDIT
+}

--- a/test/outbackcdx/WebappTest.java
+++ b/test/outbackcdx/WebappTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import outbackcdx.auth.NullAuthorizer;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -31,7 +32,7 @@ public class WebappTest {
         FeatureFlags.setExperimentalAccessControl(true);
         File root = folder.newFolder();
         DataStore manager = new DataStore(root);
-        webapp = new Webapp(manager, false);
+        webapp = new Webapp(manager, false, new NullAuthorizer());
     }
 
     @After

--- a/test/outbackcdx/WebappTest.java
+++ b/test/outbackcdx/WebappTest.java
@@ -32,7 +32,7 @@ public class WebappTest {
         FeatureFlags.setExperimentalAccessControl(true);
         File root = folder.newFolder();
         DataStore manager = new DataStore(root);
-        webapp = new Webapp(manager, false, new NullAuthorizer());
+        webapp = new Webapp(manager, false, new NullAuthorizer(), Collections.emptyMap());
     }
 
     @After

--- a/test/outbackcdx/auth/JwtAuthorizerTest.java
+++ b/test/outbackcdx/auth/JwtAuthorizerTest.java
@@ -1,0 +1,57 @@
+package outbackcdx.auth;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static outbackcdx.auth.Permission.INDEX_EDIT;
+import static outbackcdx.auth.Permission.RULES_EDIT;
+
+public class JwtAuthorizerTest {
+    @SuppressWarnings("unchecked")
+    @Test
+    public void lookup() throws AuthException {
+        Map m1 = new HashMap();
+        m1.put("two", Arrays.asList("a", "b", "c"));
+        Map m2 = new HashMap();
+        m2.put("one", m1);
+        assertEquals(Arrays.asList("a", "b", "c"), JwtAuthorizer.lookup(m2, "one/two"));
+    }
+
+    @Test
+    public void test() throws Exception {
+        RSAKey rsaJWK = new RSAKeyGenerator(2048).generate();
+        RSAKey rsaPublicJWK = rsaJWK.toPublicJWK();
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .expirationTime(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+                .claim("permissions", Arrays.asList(RULES_EDIT.toString(), INDEX_EDIT.toString()))
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.getKeyID()).build(),
+                claimsSet);
+        signedJWT.sign(signer);
+        String token = signedJWT.serialize();
+
+        JwtAuthorizer authorizer = new JwtAuthorizer(new ImmutableJWKSet<>(new JWKSet(rsaPublicJWK)), "permissions");
+        Set<Permission> permissions = authorizer.verify("beARer " + token);
+        assertEquals(EnumSet.of(RULES_EDIT, INDEX_EDIT), permissions);
+    }
+}


### PR DESCRIPTION
Allows you to restrict making changes to certain clients/users. The permissions model has separate permissions for updating index records and altering access rules and policies.

Initially two authorization options are included. The generic JWT bearer token option can be used to secure the API with many auth servers but is not currently supported by the JavaScript dashboard. The Keycloak option builds on top of this and does work with the dashboard. It would be nicer if the dashboard had generic OpenID support instead of being Keycloak-specify but the Keycloak JS adapter was easiest to get working initially. We might swap it out in future.

It should be possible to add other authorization options such as HTTP Basic or a reverse proxy that passes permissions in a header.

Fixes #19