### PR TITLE
Work in progress: secondary index on digests

### DIFF
--- a/src/outbackcdx/FeatureFlags.java
+++ b/src/outbackcdx/FeatureFlags.java
@@ -11,10 +11,12 @@ import java.util.Map;
 public class FeatureFlags {
     private static boolean experimentalAccessControl;
     private static boolean pandoraHacks;
+    private static boolean digestIndex;
 
     static {
         experimentalAccessControl = "1".equals(System.getenv("EXPERIMENTAL_ACCESS_CONTROL"));
         pandoraHacks = "1".equals(System.getenv("PANDORA_HACKS"));
+        digestIndex = "1".equals(System.getenv("DIGEST_INDEX"));
     }
 
     public static boolean pandoraHacks() {
@@ -29,10 +31,15 @@ public class FeatureFlags {
         experimentalAccessControl = enabled;
     }
 
+    public static boolean digestIndex() {
+        return digestIndex;
+    }
+
     public static Map<String, Boolean> asMap() {
         Map<String,Boolean> map = new HashMap<>();
         map.put("experimentalAccessControl", experimentalAccessControl());
         map.put("pandoraHacks", pandoraHacks());
+        map.put("digestIndex", digestIndex());
         return map;
     }
 

--- a/src/outbackcdx/Webapp.java
+++ b/src/outbackcdx/Webapp.java
@@ -201,7 +201,7 @@ class Webapp implements Web.Handler {
         Map<String,String> params = request.params();
         if (params.containsKey("q")) {
             return XmlQuery.query(request, index);
-        } else if (params.containsKey("url")) {
+        } else if (params.containsKey("url") || params.containsKey("digest")) {
             return WbCdxApi.query(request, index);
         } else {
             return collectionDetails(index.db);

--- a/src/outbackcdx/XmlQuery.java
+++ b/src/outbackcdx/XmlQuery.java
@@ -122,7 +122,7 @@ public class XmlQuery {
             writeElement(out, "file", capture.file);
             writeElement(out, "redirecturl", capture.redirecturl);
             writeElement(out, "urlkey", capture.urlkey);
-            writeElement(out, "digest", capture.digest);
+            writeElement(out, "digest", capture.digestBase32());
             writeElement(out, "httpresponsecode", capture.status);
             writeElement(out, "robotflags", "-"); // TODO
             writeElement(out, "url", capture.original);
@@ -234,9 +234,9 @@ public class XmlQuery {
             result.firstCapture = capture;
             result.lastCapture = capture;
             while (capture.urlkey.equals(result.firstCapture.urlkey)) {
-                if (previousDigest == null || !previousDigest.equals(capture.digest)) {
+                if (previousDigest == null || !previousDigest.equals(capture.digestBase32())) {
                     result.versions++;
-                    previousDigest = capture.digest;
+                    previousDigest = capture.digestBase32();
                 }
                 result.captures++;
                 result.lastCapture = capture;

--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -1,5 +1,6 @@
 package outbackcdx;
 
+import org.apache.commons.codec.binary.Base32;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -26,7 +27,7 @@ public class CaptureTest {
 
     static void assertFieldsEqual(Capture src, Capture dst) {
         assertEquals(src.compressedoffset, dst.compressedoffset);
-        assertEquals(src.digest, dst.digest);
+        assertEquals(src.digestBase32(), dst.digestBase32());
         assertEquals(src.file, dst.file);
         assertEquals(src.length, dst.length);
         assertEquals(src.mimetype, dst.mimetype);
@@ -40,7 +41,7 @@ public class CaptureTest {
     static Capture dummyRecord() {
         Capture src = new Capture();
         src.compressedoffset = 1234;
-        src.digest = "2HQQSVUDLU4NZ67TN2KS3NG5AIVBVNFB";
+        src.digest = new Base32().decode("2HQQSVUDLU4NZ67TN2KS3NG5AIVBVNFB");
         src.file = "file";
         src.length = 12345;
         src.mimetype = "mimetype";

--- a/test/outbackcdx/IndexTest.java
+++ b/test/outbackcdx/IndexTest.java
@@ -28,7 +28,7 @@ public class IndexTest {
             db = RocksDB.open(options, "test");
             defaultCf = db.getDefaultColumnFamily();
             aliasCf = db.createColumnFamily(new ColumnFamilyDescriptor("alias".getBytes(StandardCharsets.UTF_8)));
-            index = new Index("test", db, defaultCf, aliasCf, null);
+            index = new Index("test", db, defaultCf, aliasCf, null, null);
         }
     }
 


### PR DESCRIPTION
Status: Not ready for merging
Suggested-by: @kris-sigur
CC: @anjackson

The secondary index is keyed on `[digest, urlkey, date]` and contains the same values as the primary index. Enabling the secondary index will probably double the disk space used.

The secondary index will be opt in and not enabled by default for new collections. You'll be able to toggle it on and off at any time without having to resubmit your records. It will take some time for the secondary index build to complete in the background.

The query API currently looks like this: `/somecollection?digest=<base32 string>` and will support some of the same options as the PyWb/IA CDX Server API (currently `fl`, `limit` and `output`).

At the moment mixing `digest` and `url` queries is not implemented although that's possible to add if people think it would be useful.

I probably won't implement the older XML OpenSearch query API for this unless someone has a good reason for doing so.

You don't have to use SHA-1 as the digest algorithm but whatever it is must be base32 encoded as we store it as decoded bytes rather than as a string. (That's not a new limitation.)

Still to do before merging:
* [ ] Test on large collection
* [ ] API documentation
* [ ] API tests
* [ ] Make feature flags collection-specific
* [ ] Add an API for toggling feature flags on and off. Build/delete the secondary index when this happens.
* [ ] Add some UI component to the control panel for toggling feature flags.
