### PR TITLE
Added a 'latest' sort option to the api

### DIFF
--- a/src/outbackcdx/Index.java
+++ b/src/outbackcdx/Index.java
@@ -64,7 +64,7 @@ public class Index {
         ArrayList<Capture> captures = new ArrayList<Capture>();
         query(surt, filter).forEach(captures::add);
         Collections.sort(captures, (Capture cap1, Capture cap2) -> cap2.date().compareTo(cap1.date()));
-        return captures.subList(0, 1);
+        return captures;
     }
 
     /**

--- a/src/outbackcdx/Index.java
+++ b/src/outbackcdx/Index.java
@@ -58,6 +58,16 @@ public class Index {
     }
 
     /**
+     * Returns the latest result for a given url.
+     */
+    public Iterable<Capture> latestQuery(String surt, Predicate<Capture> filter) {
+        ArrayList<Capture> captures = new ArrayList<Capture>();
+        query(surt, filter).forEach(captures::add);
+        Collections.sort(captures, (Capture cap1, Capture cap2) -> cap2.date().compareTo(cap1.date()));
+        return captures.subList(0, 1);
+    }
+
+    /**
      * Returns all captures for the given url.
      */
     public Iterable<Capture> queryAP(String surt, String accessPoint) {
@@ -101,6 +111,8 @@ public class Index {
                 switch (query.sort) {
                     case DEFAULT:
                         return query(surt, filter);
+                    case LATEST:
+                        return latestQuery(surt, filter);
                     case CLOSEST:
                         return closestQuery(UrlCanonicalizer.surtCanonicalize(query.url), Long.parseLong(query.closest), filter);
                     case REVERSE:

--- a/src/outbackcdx/Query.java
+++ b/src/outbackcdx/Query.java
@@ -11,6 +11,7 @@ public class Query {
     Sort sort;
     String url;
     String closest;
+    String latest;
     String[] fields;
     boolean outputJson;
     long limit;
@@ -63,6 +64,13 @@ public class Query {
             if (closest == null) {
                 throw new IllegalArgumentException("closest={timestamp} is mandatory when using sort=closest");
             }
+        } else if (sort == Sort.LATEST) {
+            if (matchType != MatchType.EXACT) {
+                throw new IllegalArgumentException("sort=latest is currently only implemented for exact matches");
+            }
+            if (closest != null) {
+                throw new IllegalArgumentException("closest={timestamp} is not used when sort=latest");
+            }
         } else if (sort == Sort.REVERSE) {
             if (matchType != MatchType.EXACT) {
                 throw new IllegalArgumentException("sort=reverse is currently only implemented for exact matches");
@@ -91,6 +99,6 @@ public class Query {
     }
 
     enum Sort {
-        DEFAULT, CLOSEST, REVERSE
+        DEFAULT, CLOSEST, REVERSE, LATEST;
     }
 }

--- a/src/outbackcdx/Query.java
+++ b/src/outbackcdx/Query.java
@@ -11,7 +11,6 @@ public class Query {
     Sort sort;
     String url;
     String closest;
-    String latest;
     String[] fields;
     boolean outputJson;
     long limit;


### PR DESCRIPTION
Added a 'latest' sort option to the api which can be combined with limit=1 to get the latest cdx record for a url, for example:

`curl "localhost:8080/cdxtest?url=http://example.com/robots.txt&matchType=exact&sort=latest&output=jsondict&limit=1"`

I've done some testing and it seems pretty fast, but I don't have 9 billion records to test with, so if you have questions/concerns, let me know and I'll try to fix it up.