### PR TITLE
Add index version 4 for distinct records with identical url & date

### DIFF
--- a/src/outbackcdx/FeatureFlags.java
+++ b/src/outbackcdx/FeatureFlags.java
@@ -15,6 +15,7 @@ public class FeatureFlags {
     private static boolean filterPlugins;
     private static boolean acceptWrites;
     private static boolean cdx14;
+    private static int indexVersion = 3;
 
     static {
         experimentalAccessControl = "1".equals(System.getenv("EXPERIMENTAL_ACCESS_CONTROL"));
@@ -63,14 +64,26 @@ public class FeatureFlags {
         cdx14 = enabled;
     }
 
-    public static Map<String, Boolean> asMap() {
-        Map<String,Boolean> map = new HashMap<>();
+    public static Map<String, Object> asMap() {
+        Map<String,Object> map = new HashMap<>();
         map.put("experimentalAccessControl", experimentalAccessControl());
         map.put("pandoraHacks", pandoraHacks());
         map.put("secondaryMode", isSecondary());
         map.put("filterPlugins", filterPlugins());
         map.put("acceptsWrites", acceptsWrites());
         map.put("cdx14", cdx14);
+        map.put("indexVersion", indexVersion());
         return map;
+    }
+
+    public static int indexVersion() {
+        return indexVersion;
+    }
+
+    public static void setIndexVersion(int indexVersion) {
+        if (indexVersion != 3 && indexVersion != 4) {
+            throw new IllegalArgumentException("Only index versions 3 and 4 are supported, not " + indexVersion);
+        }
+        FeatureFlags.indexVersion = indexVersion;
     }
 }

--- a/src/outbackcdx/Index.java
+++ b/src/outbackcdx/Index.java
@@ -62,7 +62,7 @@ public class Index {
      * Returns all captures that match the given prefix.
      */
     public Iterable<Capture> prefixQuery(String surtPrefix, Predicate<Capture> filter) {
-        return () -> filteredCaptures(Capture.encodeKey(surtPrefix, 0), record -> record.urlkey.startsWith(surtPrefix), filter, false);
+        return () -> filteredCaptures(Capture.encodeKeyV0(surtPrefix, 0), record -> record.urlkey.startsWith(surtPrefix), filter, false);
     }
 
     public Iterable<Capture> prefixQueryAP(String surtPrefix, String accessPoint) {
@@ -77,7 +77,7 @@ public class Index {
      * Returns all captures with keys in the given range.
      */
     public Iterable<Capture> rangeQuery(String startSurt, String endSurt, Predicate<Capture> filter) {
-        return () -> filteredCaptures(Capture.encodeKey(startSurt, 0), record -> record.urlkey.compareTo(endSurt) < 0, filter, false);
+        return () -> filteredCaptures(Capture.encodeKeyV0(startSurt, 0), record -> record.urlkey.compareTo(endSurt) < 0, filter, false);
     }
 
     /**
@@ -89,7 +89,7 @@ public class Index {
 
     public Iterable<Capture> query(String surt, long from, long to, Predicate<Capture> filter) {
         String urlkey = resolveAlias(surt);
-        byte[] key = Capture.encodeKey(urlkey, from);
+        byte[] key = Capture.encodeKeyV0(urlkey, from);
         return () -> filteredCaptures(key, record -> record.urlkey.equals(urlkey) && record.timestamp <= to, filter, false);
     }
 
@@ -113,7 +113,7 @@ public class Index {
 
     public Iterable<Capture> reverseQuery(String surt, long from, long to, Predicate<Capture> filter) {
         String urlkey = resolveAlias(surt);
-        byte[] key = Capture.encodeKey(urlkey, to);
+        byte[] key = Capture.encodeKeyV0(urlkey, to);
         return () -> filteredCaptures(key, record -> record.urlkey.equals(urlkey) && record.timestamp >= from, filter, true);
     }
 
@@ -122,7 +122,7 @@ public class Index {
      */
     public Iterable<Capture> closestQuery(String surt, long targetTimestamp, Predicate<Capture> filter) {
         String urlkey = resolveAlias(surt);
-        byte[] key = Capture.encodeKey(urlkey, targetTimestamp);
+        byte[] key = Capture.encodeKeyV0(urlkey, targetTimestamp);
         Predicate<Capture> scope = record -> record.urlkey.equals(urlkey);
         return () -> new ClosestTimestampIterator(targetTimestamp,
                 filteredCaptures(key, scope, filter, false),
@@ -239,14 +239,14 @@ public class Index {
      * Perform a query without first resolving aliases.
      */
     private Iterable<Capture> rawQuery(String key, Predicate<Capture> filter, boolean reverse) {
-        return () -> filteredCaptures(Capture.encodeKey(key, 0), record -> record.urlkey.equals(key), filter, reverse);
+        return () -> filteredCaptures(Capture.encodeKeyV0(key, 0), record -> record.urlkey.equals(key), filter, reverse);
     }
 
     /**
      * Returns all captures starting from the given key.
      */
     Iterable<Capture> capturesAfter(String start) {
-        return () -> filteredCaptures(Capture.encodeKey(start, 0), record -> true, null, false);
+        return () -> filteredCaptures(Capture.encodeKeyV0(start, 0), record -> true, null, false);
     }
 
     public String resolveAlias(String surt) {

--- a/src/outbackcdx/Main.java
+++ b/src/outbackcdx/Main.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
 public class Main {
     public static void usage() {
         System.err.println("Usage: java " + Main.class.getName() + " [options...]");
-        System.err.println("");
+        System.err.println();
         System.err.println("  -b bindaddr           Bind to a particular IP address");
         System.err.println("  -d datadir            Directory to store index data under");
         System.err.println("  -i                    Inherit the server socket via STDIN (for use with systemd, inetd etc)");
@@ -53,10 +53,15 @@ public class Main {
         System.err.println("  --update-interval poll-interval    Polling frequency for upstream changes, in seconds. Default: 10");
         System.err.println("  --accept-writes                    Allow writes to this node, even though running as a secondary");
         System.err.println("  --batch-size                       Approximate max size (in bytes) per replication batch");
+        System.err.println();
+        System.err.println("Enable experimental index versions. DANGER: Upgrading a version 3 index to version 4 is not yet supported and " +
+                "updating or deleting existing version 3 records will silently fail.");
+        System.err.println("  --index-version 4     Treats records as distinct if they have a different filename or offset" +
+                "                                   even if they have identical url and date");
         System.exit(1);
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         boolean undertow = false;
         String host = null;
         int port = 8080;
@@ -92,6 +97,11 @@ public class Main {
                     break;
                 case "-i":
                     inheritSocket = true;
+                    break;
+                case "--index-version":
+                    System.err.println("WARNING: Experimental index version 4 enabled. Do not use this option (yet) on an " +
+                            "pre-existing version 3 index. Updating or deleting older records will silently fail.");
+                    FeatureFlags.setIndexVersion(Integer.parseInt(args[++i]));
                     break;
                 case "-j":
                     try {

--- a/test-integration/test-openwayback.sh
+++ b/test-integration/test-openwayback.sh
@@ -13,8 +13,8 @@ function fetch {
 #
 
 mkdir -p deps
-fetch wayback.war http://central.maven.org/maven2/org/netpreserve/openwayback/openwayback-webapp/2.3.1/openwayback-webapp-2.3.1.war
-fetch jetty-runner.jar http://central.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.0.M1/jetty-runner-9.4.0.M1.jar
+fetch wayback.war https://repo1.maven.org/maven2/org/netpreserve/openwayback/openwayback-webapp/2.3.1/openwayback-webapp-2.3.1.war
+fetch jetty-runner.jar https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.0.M1/jetty-runner-9.4.0.M1.jar
 
 #
 # Prepare wayback

--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -24,6 +24,15 @@ public class CaptureTest {
         assertEquals(src.date().getTime(), 1388579640000L);
     }
 
+    @Test
+    public void testV4Encoding() {
+        Capture src = dummyRecord();
+        byte[] key = src.encodeKey(4);
+        byte[] value = src.encodeValue(4);
+        Capture dst = new Capture(key, value);
+        assertFieldsEqual(src, dst);
+    }
+
     static void assertFieldsEqual(Capture src, Capture dst) {
         assertEquals(src.compressedoffset, dst.compressedoffset);
         assertEquals(src.digest, dst.digest);


### PR DESCRIPTION
Gated behind a feature flag as the version 3 to 4 upgrade process has not been implemented yet. To try the index format use command-line flag `--index-version 4`.

Warning: Using this on a version 3 index will only work partially. Queries will probably work but version 3 records cannot be deleted and updating them will create duplicates.

There may be a better way to encode the v4 keys (suggestions?). It's made awkward by the fact the urlkey field in v0 keys is't terminated we rely on the timestamp always being a fixed 8 bytes to calculate the length of it.

The reason I make the v4 keys a simple extension of the v0 keys is so that querying should work correctly for indexes with mixed record versions. This gives us a pathway to incremental upgrading without extensive downtime.

#77