### PR TITLE
Add option to compute a field using a HMAC or digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Example nginx configuration:
 ```nginx
 location /warcs/ {
    secure_link $arg_md5,$arg_expires;
-   secure_link_md5 "$secure_link_expires|$uri|secret";
+   secure_link_md5 "$secure_link_expires|$uri|$http_range|secret";
    if ($secure_link != "1") { return 403; }
    ...
 }
@@ -369,7 +369,7 @@ location /warcs/ {
 Corresponding OutbackCDX option:
 
 ```
---hmac-field url md5 '$expires|/warcs/$filename|$secret_key'
+--hmac-field url md5 '$expires|/warcs/$filename|$range|$secret_key'
      'http://nginx.example.org/warcs/$filename?expires=$expires&md5=$hmac_base64_url'
      secret 3600
 ```
@@ -385,7 +385,7 @@ location /warcs/ {
    secure_link_hmac  $arg_st,$arg_ts,$arg_e;
    secure_link_hmac_algorithm sha256;
    secure_link_hmac_secret secret;
-   secure_link_hmac_message $uri|$arg_ts|$arg_e;
+   secure_link_hmac_message $uri|$arg_ts|$arg_e|$http_range;
    if ($secure_link_hmac != "1") { return 403; }
    ...
 }
@@ -394,7 +394,7 @@ location /warcs/ {
 Corresponding OutbackCDX option:
 
 ```
---hmac-field url Hmacsha256 '/warcs/$filename|$now|3600'
+--hmac-field url Hmacsha256 '/warcs/$filename|$now|3600|$http_range'
      'http://nginx.example.org/warcs/$filename?st=$hmac_base64_url&ts=$now&e=3600
      secret 0
 ```

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ variables are available in templates:
 
 * `$dollar` - a dollar sign ("$")
 * `$expires` - expiry time in seconds since unix epoch
+* `$expires_hex` - expiry time in hexadecimal seconds since unix epoch
 * `$expires_iso8601` - expiry time as a UTC ISO 8601 timestamp
 * `$hmac_base64` - computed hmac/digest value as a base64 string (only available in value template)
 * `$hmac_base64_pct` - computed hmac/digest value as a base64 string with + encoded as %2B
@@ -341,6 +342,7 @@ variables are available in templates:
 * `$hmac_hex` - computed hmac/digest value as a hex string (only available in value template)
 * `$secret_key` - the secret key (only available in message template)
 * `$now` - current time in seconds since unix epoch
+* `$now_hex` - current time in hexadecimal seconds since unix epoch
 * `$now_iso8601` - current time as a UTC ISO 8601 timestamp
 * `$CR` - a carriage return ("\r")
 * `$CRLF` - a carriage return line feed ("\r\n")
@@ -369,7 +371,7 @@ location /warcs/ {
 Corresponding OutbackCDX option:
 
 ```
---hmac-field url md5 '$expires|/warcs/$filename|$range|$secret_key'
+--hmac-field warcurl md5 '$expires|/warcs/$filename|$range|$secret_key'
      'http://nginx.example.org/warcs/$filename?expires=$expires&md5=$hmac_base64_url'
      secret 3600
 ```
@@ -394,9 +396,28 @@ location /warcs/ {
 Corresponding OutbackCDX option:
 
 ```
---hmac-field url Hmacsha256 '/warcs/$filename|$now|3600|$http_range'
+--hmac-field warcurl Hmacsha256 '/warcs/$filename|$now|3600|$http_range'
      'http://nginx.example.org/warcs/$filename?st=$hmac_base64_url&ts=$now&e=3600
      secret 0
+```
+
+#### lighttpd [mod_secdownload](https://redmine.lighttpd.net/projects/lighttpd/wiki/Docs_ModSecDownload)
+
+Example lighttpd configuration:
+
+```
+secdownload.algorithm       = "hmac-sha256" 
+secdownload.secret          = "secret" 
+secdownload.document-root   = "/data/warcs/" 
+secdownload.uri-prefix      = "/warcs/" 
+secdownload.timeout         = 3600
+```
+
+Corresponding OutbackCDX option:
+
+```
+--hmac-field warcurl Hmacsha256 /$now_hex/$filename
+   http://lighttpd.example.org/warcs/$hmac_base64_url/$now_hex/$filename secret 0
 ```
 
 #### S3 signed URLs

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Corresponding OutbackCDX option:
 
 ```
 --hmac-field url md5 '$expires|/warcs/$filename|$secret_key'
-     'http://nginx.example.org/warcs/$filename?expires=$expires&md5=$hmac_hex'
+     'http://nginx.example.org/warcs/$filename?expires=$expires&md5=$hmac_base64_url'
      secret 3600
 ```
 

--- a/README.md
+++ b/README.md
@@ -416,8 +416,8 @@ secdownload.timeout         = 3600
 Corresponding OutbackCDX option:
 
 ```
---hmac-field warcurl Hmacsha256 /$now_hex/$filename
-   http://lighttpd.example.org/warcs/$hmac_base64_url/$now_hex/$filename secret 0
+--hmac-field warcurl Hmacsha256 '/$now_hex/$filename'
+   'http://lighttpd.example.org/warcs/$hmac_base64_url/$now_hex/$filename' secret 0
 ```
 
 #### S3 signed URLs

--- a/src/outbackcdx/Capture.java
+++ b/src/outbackcdx/Capture.java
@@ -433,6 +433,8 @@ public class Capture {
                 return (originalCompressedoffset != -1) ? originalCompressedoffset : "-";
             case "originalFilename":
                 return originalFile;
+            case "range":
+                return "bytes=" + compressedoffset + "-" + (compressedoffset + length - 1);
             default:
                 throw new IllegalArgumentException("no such capture field: " + field);
         }

--- a/src/outbackcdx/ComputedField.java
+++ b/src/outbackcdx/ComputedField.java
@@ -1,0 +1,5 @@
+package outbackcdx;
+
+public interface ComputedField {
+    Object get(Capture capture);
+}

--- a/src/outbackcdx/HmacField.java
+++ b/src/outbackcdx/HmacField.java
@@ -1,0 +1,141 @@
+package outbackcdx;
+
+import org.apache.commons.codec.binary.Hex;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class HmacField implements ComputedField {
+    Pattern VARIABLE_PATTERN = Pattern.compile("\\$([a-zA-Z0-9_]+|\\{[a-zA-Z0-9_]+})");
+
+    private final String algorithm;
+    private final String messageTemplate;
+    private final String fieldTemplate;
+    private final String key;
+    private final int expiresSecs;
+    private boolean useDigest;
+
+    public HmacField(String algorithm, String messageTemplate, String fieldTemplate, String key, int expiresSecs) {
+        this.algorithm = algorithm;
+        this.messageTemplate = messageTemplate;
+        this.fieldTemplate = fieldTemplate;
+        this.key = key;
+        this.expiresSecs = expiresSecs;
+
+        // detect if algorithm is a Mac or MessageDigest
+        try {
+            Mac.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            try {
+                MessageDigest.getInstance(algorithm);
+                useDigest = true;
+            } catch (NoSuchAlgorithmException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        validateConfig();
+    }
+
+    /**
+     * Perform a test operation so we fail on startup if the algorithm or template is bogus.
+     */
+    private void validateConfig() {
+        Capture capture = new Capture();
+        capture.file = "test.warc.gz";
+        capture.urlkey = "test";
+        capture.original = "test.warc.gz";
+        capture.robotflags = "";
+        capture.mimetype = "text/html";
+        capture.digest = "example";
+        capture.redirecturl = "";
+        get(capture);
+    }
+
+    public Object get(Capture capture) {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant expires = now.plusSeconds(expiresSecs);
+        String message = interpolate(messageTemplate, capture, now, expires, null, key);
+        byte[] hmacBytes;
+        try {
+            if (useDigest) {
+                MessageDigest digest = MessageDigest.getInstance(algorithm);
+                hmacBytes = digest.digest(message.getBytes(UTF_8));
+            } else {
+                Mac hmac = Mac.getInstance(algorithm);
+                hmac.init(new SecretKeySpec(key.getBytes(UTF_8), algorithm));
+                hmacBytes = hmac.doFinal(message.getBytes(UTF_8));
+            }
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+        String hmacHex = Hex.encodeHexString(hmacBytes);
+        return interpolate(fieldTemplate, capture, now, expires, hmacBytes, null);
+    }
+
+    private String interpolate(String template, Capture capture, Instant now, Instant expires, byte[] hmac, String key) {
+        StringBuffer buffer = new StringBuffer();
+        Matcher matcher = VARIABLE_PATTERN.matcher(template);
+        while (matcher.find()) {
+            String variable = matcher.group(1);
+            String value;
+            switch (variable) {
+                case "expires_iso8601":
+                    value = expires.toString();
+                    break;
+                case "expires":
+                    value = Long.toString(expires.getEpochSecond());
+                    break;
+                case "hmac_hex":
+                    value = Hex.encodeHexString(hmac);
+                    break;
+                case "hmac_base64":
+                    value = Base64.getEncoder().encodeToString(hmac);
+                    break;
+                case "hmac_base64_pct":
+                    value = Base64.getEncoder().encodeToString(hmac).replace("+", "%2B");
+                    break;
+                case "hmac_base64_url":
+                    value = Base64.getUrlEncoder().encodeToString(hmac);
+                    break;
+                case "now_iso8601":
+                    value = now.toString();
+                    break;
+                case "now":
+                    value = Long.toString(now.getEpochSecond());
+                    break;
+                case "secret_key":
+                    value = key;
+                    break;
+                case "dollar":
+                    value = "$";
+                    break;
+                case "CR":
+                    value = "\r";
+                    break;
+                case "LF":
+                    value = "\n";
+                    break;
+                case "CRLF":
+                    value = "\r\n";
+                    break;
+                default:
+                    value = capture.get(variable).toString();
+                    break;
+            }
+            matcher.appendReplacement(buffer, value);
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+}

--- a/src/outbackcdx/HmacField.java
+++ b/src/outbackcdx/HmacField.java
@@ -96,23 +96,29 @@ public class HmacField implements ComputedField {
                 case "expires":
                     value = Long.toString(expires.getEpochSecond());
                     break;
+                case "expires_hex":
+                    value = Long.toHexString(expires.getEpochSecond());
+                    break;
                 case "hmac_hex":
                     value = Hex.encodeHexString(hmac);
                     break;
                 case "hmac_base64":
-                    value = Base64.getEncoder().encodeToString(hmac);
+                    value = Base64.getEncoder().withoutPadding().encodeToString(hmac);
                     break;
                 case "hmac_base64_pct":
-                    value = Base64.getEncoder().encodeToString(hmac).replace("+", "%2B");
+                    value = Base64.getEncoder().withoutPadding().encodeToString(hmac).replace("+", "%2B");
                     break;
                 case "hmac_base64_url":
-                    value = Base64.getUrlEncoder().encodeToString(hmac);
+                    value = Base64.getUrlEncoder().withoutPadding().encodeToString(hmac);
                     break;
                 case "now_iso8601":
                     value = now.toString();
                     break;
                 case "now":
                     value = Long.toString(now.getEpochSecond());
+                    break;
+                case "now_hex":
+                    value = Long.toHexString(now.getEpochSecond());
                     break;
                 case "secret_key":
                     value = key;

--- a/src/outbackcdx/WbCdxApi.java
+++ b/src/outbackcdx/WbCdxApi.java
@@ -8,6 +8,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.Map;
 
 import com.google.gson.stream.JsonWriter;
 
@@ -23,7 +24,15 @@ import outbackcdx.NanoHTTPD.Response;
  * pywb: https://github.com/ikreymer/pywb/wiki/CDX-Server-API
  */
 public class WbCdxApi {
-    public static Response queryIndex(Web.Request request, Index index, Iterable<FilterPlugin> filterPlugins) {
+    private final Iterable<FilterPlugin> filterPlugins;
+    private final Map<String, ComputedField> computedFields;
+
+    public WbCdxApi(Iterable<FilterPlugin> filterPlugins, Map<String, ComputedField> computedFields) {
+        this.filterPlugins = filterPlugins;
+        this.computedFields = computedFields;
+    }
+
+    public Response queryIndex(Web.Request request, Index index) {
         Query query = new Query(request.params(), filterPlugins);
         Iterable<Capture> captures = query.execute(index);
 
@@ -59,12 +68,20 @@ public class WbCdxApi {
         return response;
     }
 
+    private Object computeField(Capture capture, String field) {
+        ComputedField computed = computedFields.get(field);
+        if (computed != null) {
+            return computed.get(capture);
+        }
+        return capture.get(field);
+    }
+
     interface OutputFormat {
         void writeCapture(Capture capture) throws IOException;
         void close() throws IOException;
     }
 
-    static class JsonDictFormat implements OutputFormat {
+    class JsonDictFormat implements OutputFormat {
         private final JsonWriter out;
         private final String[] fields;
 
@@ -78,7 +95,7 @@ public class WbCdxApi {
         public void writeCapture(Capture capture) throws IOException {
             out.beginObject();
             for (String field : fields) {
-                Object value = capture.get(field);
+                Object value = computeField(capture, field);
                 if (value instanceof Long) {
                     out.name(field).value((long) value);
                 } else if (value instanceof Integer) {
@@ -103,7 +120,7 @@ public class WbCdxApi {
      * Formats captures as a JSON array. Supports the field names used by both
      * pywb and wayback-cdx-server.
      */
-    static class JsonFormat implements OutputFormat {
+    class JsonFormat implements OutputFormat {
         private final JsonWriter out;
         private final String[] fields;
 
@@ -117,7 +134,7 @@ public class WbCdxApi {
         public void writeCapture(Capture capture) throws IOException {
             out.beginArray();
             for (String field : fields) {
-                Object value = capture.get(field);
+                Object value = computeField(capture, field);
                 if (value instanceof Long) {
                     out.value((long) value);
                 } else if (value instanceof Integer) {
@@ -138,7 +155,7 @@ public class WbCdxApi {
         }
     }
 
-    static class TextFormat implements OutputFormat {
+    class TextFormat implements OutputFormat {
         private final Writer out;
         private final String[] fields;
 
@@ -151,7 +168,7 @@ public class WbCdxApi {
         public void writeCapture(Capture capture) throws IOException {
             for (int i = 0; i < fields.length; i++) {
                 String field = fields[i];
-                Object value = capture.get(field);
+                Object value = computeField(capture, field);
                 out.write(value.toString());
                 if (i < fields.length - 1) {
                     out.write(' ');

--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -33,6 +33,11 @@ public class CaptureTest {
         assertFieldsEqual(src, dst);
     }
 
+    @Test
+    public void testRange() {
+        assertEquals("bytes=1234-13578", dummyRecord().get("range"));
+    }
+
     static void assertFieldsEqual(Capture src, Capture dst) {
         assertEquals(src.compressedoffset, dst.compressedoffset);
         assertEquals(src.digest, dst.digest);

--- a/test/outbackcdx/HmacFieldTest.java
+++ b/test/outbackcdx/HmacFieldTest.java
@@ -1,0 +1,29 @@
+package outbackcdx;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HmacFieldTest {
+    @Test
+    public void hmacsha256() {
+        HmacField field = new HmacField("Hmacsha256", "$filename $offset $length",
+                "$filename?hmac=$hmac_hex", "testkey", 3600);
+        Capture capture = new Capture();
+        capture.file = "example.warc.gz";
+        capture.compressedoffset = 400;
+        capture.length = 200;
+        assertEquals("example.warc.gz?hmac=9e27a71a89b33a0e66a13288140ca26427fd2689a230881159935f0268c3c1f0", field.get(capture));
+    }
+
+    @Test
+    public void hmacmd5() {
+        HmacField field = new HmacField("md5", "$filename $offset $length $secret_key",
+                "$filename?hmac=$hmac_hex", "testkey", 3600);
+        Capture capture = new Capture();
+        capture.file = "example.warc.gz";
+        capture.compressedoffset = 400;
+        capture.length = 200;
+        assertEquals("example.warc.gz?hmac=1894419ebacc473d63f4f2d8088229b2", field.get(capture));
+    }
+}

--- a/test/outbackcdx/ReplicationFeaturesTest.java
+++ b/test/outbackcdx/ReplicationFeaturesTest.java
@@ -9,14 +9,13 @@ import outbackcdx.auth.Permit;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 
 import static org.junit.Assert.assertEquals;
 import static outbackcdx.NanoHTTPD.Method.*;
 import static outbackcdx.NanoHTTPD.Response.Status.OK;
-import static outbackcdx.NanoHTTPD.Response.Status.UNAUTHORIZED;
-
 
 
 public class ReplicationFeaturesTest {
@@ -31,7 +30,7 @@ public class ReplicationFeaturesTest {
     public void setUp() throws IOException {
         File root = folder.newFolder();
         manager = new DataStore(root, 256, null, Long.MAX_VALUE, null);
-        webapp = new Webapp(manager, false, Collections.emptyMap(), null);
+        webapp = new Webapp(manager, false, Collections.emptyMap(), null, Collections.emptyMap());
     }
 
     @After

--- a/test/outbackcdx/WebappTest.java
+++ b/test/outbackcdx/WebappTest.java
@@ -43,7 +43,7 @@ public class WebappTest {
         UrlCanonicalizer canon = new UrlCanonicalizer(new ByteArrayInputStream(yaml.getBytes("UTF-8")));
 
         DataStore manager = new DataStore(root, -1, null, Long.MAX_VALUE, canon);
-        webapp = new Webapp(manager, false, Collections.emptyMap(), canon);
+        webapp = new Webapp(manager, false, Collections.emptyMap(), canon, Collections.emptyMap());
     }
 
     @After


### PR DESCRIPTION
Possible implementation of #79.

### TODO

* [x] Range header support - probably just need a $range template variable that evaluates to the string `"bytes=" + offset + "-" + (offset + length - 1)` which can correspond to `$http_range` in nginx
* [ ] Secret keys shouldn't appear in command-line parameters, do something about this
* [ ] Maybe convenience options for configuring the S3 template automatically
* [ ] Test S3
* [ ] Check we have the needed pieces support AWS V4 signing (it looks like that might be needed for the range header?)
* [ ] Figure out an example for Apache

### Example query

```
$ curl 'http://localhost:8080/foo?url=http://example.com&fl=original,timestamp,warcurl,range'
http://example.com/ 20140103030321 http://nginx-server/warcs/example.warc.gz?expires=1583828836&md5=yPf8VITsUZkldGIt24V3zg bytes=333-1375
http://example.com/ 20140103030341 http://nginx-server/warcs/example.warc.gz?expires=1583828836&md5=iZdrAQ0hdmxPTMuWiSoVUg bytes=1864-2416
```


### nginx example

Example nginx configuration:

```nginx
location /warcs/ {
   secure_link $arg_md5,$arg_expires;
   secure_link_md5 "$secure_link_expires|$uri|$http_range|secret";
   if ($secure_link != "1") { return 403; }
   ...
}
```

Corresponding OutbackCDX option:

```
--hmac-field warcurl md5 '$expires|/warcs/$filename|$range|$secret_key'
     'http://nginx-server/warcs/$filename?expires=$expires&md5=$hmac_base64_url'
     secret 3600
```

### S3 example (yet to be tested)

Replace `s3-access-key-id`, `s3-secret-key` and `bucket` with appropriate values:

```
--hmac-field warcurl Hmacsha1 'GET$LF$LF$LF$expires$LF/bucket/$filename'
     'https://s3.amazonaws.com/bucket/$filename?AWSAccessKeyId=s3-access-key-id&Expires=$expires&Signature=$hmac_base64_pct'
     s3-secret-key 3600 
```