### PR TITLE
pad timestamps shorter than 14 chars

### DIFF
--- a/src/outbackcdx/Capture.java
+++ b/src/outbackcdx/Capture.java
@@ -390,8 +390,14 @@ public class Capture {
         return parseTimestamp(timestamp);
     }
 
+    static final String PAD_TIMESTAMP = "00000000000000"; // we expect 14 chars
+
     public static Date parseTimestamp(long timestamp) {
-        return Date.from(LocalDateTime.parse(Long.toString(timestamp), arcTimeFormat).toInstant(ZoneOffset.UTC));
+        String timestampstr = Long.toString(timestamp);
+        if (timestampstr.length() < 14) {
+            timestampstr = timestampstr + PAD_TIMESTAMP.substring(timestampstr.length());
+        }
+        return Date.from(LocalDateTime.parse(timestampstr, arcTimeFormat).toInstant(ZoneOffset.UTC));
     }
 
     /**


### PR DESCRIPTION
outbackcdx allows ingest of records with timestamps shorter than 14 characters, but queries returning such records log this error:

`java.time.format.DateTimeParseException: Text '200012041600' could not be parsed at index 12
        at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949)
        at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851)
        at java.time.LocalDateTime.parse(LocalDateTime.java:492)
        at outbackcdx.Capture.parseTimestamp(Capture.java:257)
        ...
`

Padding shorter timestamps with 0s should help us return them.