### PR TITLE
Append POST data to canonized url

### DIFF
--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -34,6 +34,19 @@ public class CaptureTest {
     }
 
     @Test
+    public void testWbPostDataExtraction() {
+        UrlCanonicalizer canonicalizer = new UrlCanonicalizer();
+
+        // simple url with no parameters
+        Capture cap = Capture.fromCdxLine("com,test)/append?__wb_post_data=dGVzdAo= 20200528143535 https://test.com/append application/json 202 2WC5VZGPEJIVA6BQPKMISFH7ISBVWYUQ - - 467 4846509 test.warc.gz", canonicalizer);
+        assertEquals("com,test)/append?__wb_post_data=dGVzdAo=", cap.urlkey);
+
+        // url with parameters
+        cap = Capture.fromCdxLine("com,test)/append?x=1&__wb_post_data=dGVzdAo= 20200528143535 https://test.com/append?x=1 application/json 202 2WC5VZGPEJIVA6BQPKMISFH7ISBVWYUQ - - 467 4846509 test.warc.gz", canonicalizer);
+        assertEquals("com,test)/append?x=1&__wb_post_data=dGVzdAo=", cap.urlkey);
+    }
+
+    @Test
     public void testRange() {
         assertEquals("bytes=1234-13578", dummyRecord().get("range"));
     }
@@ -67,4 +80,5 @@ public class CaptureTest {
         src.robotflags = "AFIGX";
         return src;
     }
+
 }

--- a/test/outbackcdx/IndexTest.java
+++ b/test/outbackcdx/IndexTest.java
@@ -60,6 +60,19 @@ public class IndexTest {
     }
 
     @Test
+    public void testPostData() throws IOException {
+        try (Index.Batch batch = index.beginUpdate()) {
+            batch.putCapture(Capture.fromCdxLine("org,post)/?__wb_post_data=dGVzdAo= 20200528143307 http://post.org/ text/html 200 - - 0 w1", index.canonicalizer));
+            batch.putCapture(Capture.fromCdxLine("org,post)/?__wb_post_data=dGVzdDIK 20200528143307 http://post.org/ text/html 200 - - 0 w1", index.canonicalizer));
+            batch.commit();
+        }
+
+        List<Capture> results = new ArrayList<>();
+        index.closestQuery("org,post)/?__wb_post_data=dGVzdAo=", 20200528143307L, null).forEach(results::add);
+        assertEquals("org,post)/?__wb_post_data=dGVzdAo=", results.get(0).urlkey);
+    }
+
+    @Test
     public void testDelete() throws IOException {
         try (Index.Batch batch = index.beginUpdate()) {
             batch.putCapture(Capture.fromCdxLine("- 20050101000000 http://a.org/ text/html 200 - - 0 w1", index.canonicalizer));


### PR DESCRIPTION
### Problem
Currently, POST data query parameters are ignored by the outbackcdx indexing process (__wb_post_data coming from pywb cdx-indexer or __warc_post_data coming from cdxj-indexer with -11 flag). This leads to playback problems of recorded webpages such as http://corona-data.ch. This webpage POSTs several XHR calls to the same endpoint, but with different parameters. A more detailed description of the problem can be found at webrecorder/pywb#585.

### Analysis
The POST data is not indexed because outbackcdx uses its own canonicalizer based on the `original url`. The POST data query parameter is only added to the `urlkey` (surt-canonized url) by the cdx-indexer.

### Proposed solution
If POST data is available in the passed `urlkey` at indexing time, it is copied and appended to the new surt after canonicalization. This is a change that can be done at indexing time in a locally isolated place (`fromCdxLine`). It does not interfere with the current canonicalization and the canonicalization does not change the base64 encoded POST-data value.

### Testing with pywb
The proposed approach has been tested with pywb using the following configuraion: `api_url: http://outbackcdx/collection?closest={closest}&sort=closest&url={alt_url}`. The page http://corona-data.ch has been played back successfully.

### Possible issues within pywb 
I think using `alt_url` in the template is not optimal, since it bypasses the fuzzy rulesets of pywb. I'm working on a solution for pywb to make the `RemoteIndexSource` work better with the `__wb_post_data` and the `url` field, but will follow this on a seperate track.

### Possible effects on existing systems
If new CDX data is indexed with POST-data included (`cdx-indexer -p`), there could possibly be issues in replay with exact matches. I'm also not sure what this means for OpenWayback with OutbackCDX (do we need to index twice - with/and without POST-data to make this work?)
