### PR TITLE
Use adoptopenjdk-11, add ldb and sst_dump tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM maven:3-jdk-8 as build-env
+FROM maven:3-adoptopenjdk-11 as build-env
+
+RUN apt-get update \
+ && apt-get install -y libsnappy-dev \
+ && apt-get install -y build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+# add rocksdb tools
+# see outbackcdx pom.xml for rocksdb version (rocksdbjni) and
+# check branches with https://github.com/facebook/rocksdb
+RUN cd /tmp && \
+    git clone https://github.com/facebook/rocksdb.git && \
+    cd rocksdb && \
+    git checkout 6.0.fb && \
+    DEBUG_LEVEL=0 make tools && \
+    cp /tmp/rocksdb/ldb /usr/bin/ && \
+    cp /tmp/rocksdb/sst_dump /usr/bin/
 
 WORKDIR /build
 
@@ -13,12 +29,20 @@ RUN export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 && \
     mvn -B -s /usr/share/maven/ref/settings-docker.xml -DskipTests package && \
     mvn package
 
-FROM java:8
+FROM adoptopenjdk:11-jdk-hotspot
+
+RUN apt-get update && apt-get install -y libsnappy-dev dumb-init \
+ && rm -rf /var/lib/apt/lists/*
+
 
 COPY --from=build-env /build/target/outbackcdx-*.jar outbackcdx.jar
+COPY --from=build-env /usr/bin/ldb /usr/bin
+COPY --from=build-env /usr/bin/sst_dump /usr/bin
 
 RUN mkdir /cdx-data
 
 EXPOSE 8080
 
-CMD java -jar outbackcdx.jar -d /cdx-data -p 8080 -b 0.0.0.0
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD java -jar outbackcdx.jar -v -d /cdx-data -p 8080 -b 0.0.0.0
+


### PR DESCRIPTION
Updated dockerfile to use Java 11 and add rocksdb tools for improved debugging, dumps, ... 

- Use dumb-init (see https://github.com/Yelp/dumb-init)
- Use adoptopenjdk-11
- Use specific version of ldb and sst_dump (see https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool)
- Running successfully in production with this image since July 2019

Drawbacks: building the `ldb` and `sst_dump` tools takes some time (docker build). I added this in the beginning of the file to take advantage of layer caching. Repeated rebuilding of outbackcdx will be quite fast.
