### PR TITLE
Dockerfile - fix gcc9 build of older rocksdb versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cd /tmp && \
     git clone https://github.com/facebook/rocksdb.git && \
     cd rocksdb && \
     git checkout 6.0.fb && \
-    DEBUG_LEVEL=0 make tools && \
+    DEBUG_LEVEL=0 CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=pessimizing-move -Wno-error=class-memaccess' make tools && \
     cp /tmp/rocksdb/ldb /usr/bin/ && \
     cp /tmp/rocksdb/sst_dump /usr/bin/
 


### PR DESCRIPTION
Fixes a rocksdb build issue in the dockerfile, see  see https://github.com/yinqiwen/ardb/issues/484. This is fixed with RocksDB versions >=6.8.1 (outbackcdx is currently using 6.0.x)
