### PR TITLE
Implement numreturned and numresults in XmlQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Usage: java -jar outbackcdx.jar [options...]
   -k url realm clientid Use a Keycloak server for authorization
   -m max-open-files     Limit the number of open .sst files to control memory usage
                         (default 396 based on system RAM and ulimit -n)
+  --max-num-results N   Max number of records to scan to calculate numresults statistic in the XML protocol (default 10000)
   -p port               Local port to listen on
   -t count              Number of web server threads
   -r count              Cap on number of rocksdb records to scan to serve a single request
@@ -143,15 +144,6 @@ OpenWayback "OpenSearch" XML:
     $ curl 'http://localhost:8080/myindex?q=type:urlquery+url:http%3A%2F%2Fexample.org%2F'
     <?xml version="1.0" encoding="UTF-8"?>
     <wayback>
-       <request>
-           <startdate>19960101000000</startdate>
-           <enddate>20180526162512</enddate>
-           <type>urlquery</type>
-           <firstreturned>0</firstreturned>
-           <url>org,example)/</url>
-           <resultsrequested>10000</resultsrequested>
-           <resultstype>resultstypecapture</resultstype>
-       </request>
        <results>
            <result>
                <compressedoffset>396</compressedoffset>
@@ -167,6 +159,17 @@ OpenWayback "OpenSearch" XML:
                <capturedate>20030402160014</capturedate>
            </result>
        </results>
+       <request>
+           <startdate>19960101000000</startdate>
+           <enddate>20180526162512</enddate>
+           <type>urlquery</type>
+           <firstreturned>0</firstreturned>
+           <url>org,example)/</url>
+           <resultsrequested>10000</resultsrequested>
+           <resultstype>resultstypecapture</resultstype>
+           <numreturned>1</numreturned>
+           <numresults>1</numresults>
+       </request>
     </wayback>
 
 Query URLs that match a given URL prefix:

--- a/test-integration/test-openwayback.sh
+++ b/test-integration/test-openwayback.sh
@@ -52,4 +52,6 @@ check $WAYBACK_URL/*/$PAGE 20161016214133
 check $WAYBACK_URL/*/$PAGE 20161016214156
 check $WAYBACK_URL/20161016214133/$PAGE 'Simple Text Documents'
 
-read -n1 -r -p "Press any key to continue..." key
+if [ -n "${WAIT-}" ]; then
+  read -n1 -r -p "Press any key to continue..." key
+fi

--- a/test-integration/test-openwayback.sh
+++ b/test-integration/test-openwayback.sh
@@ -52,3 +52,4 @@ check $WAYBACK_URL/*/$PAGE 20161016214133
 check $WAYBACK_URL/*/$PAGE 20161016214156
 check $WAYBACK_URL/20161016214133/$PAGE 'Simple Text Documents'
 
+read -n1 -r -p "Press any key to continue..." key

--- a/test/outbackcdx/ReplicationFeaturesTest.java
+++ b/test/outbackcdx/ReplicationFeaturesTest.java
@@ -9,7 +9,6 @@ import outbackcdx.auth.Permit;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -30,7 +29,7 @@ public class ReplicationFeaturesTest {
     public void setUp() throws IOException {
         File root = folder.newFolder();
         manager = new DataStore(root, 256, null, Long.MAX_VALUE, null);
-        webapp = new Webapp(manager, false, Collections.emptyMap(), null, Collections.emptyMap());
+        webapp = new Webapp(manager, false, Collections.emptyMap(), null, Collections.emptyMap(), 10000);
     }
 
     @After

--- a/test/outbackcdx/WebappTest.java
+++ b/test/outbackcdx/WebappTest.java
@@ -48,7 +48,7 @@ public class WebappTest {
         UrlCanonicalizer canon = new UrlCanonicalizer(new ByteArrayInputStream(yaml.getBytes("UTF-8")));
 
         DataStore manager = new DataStore(root, -1, null, Long.MAX_VALUE, canon);
-        webapp = new Webapp(manager, false, Collections.emptyMap(), canon, Collections.emptyMap());
+        webapp = new Webapp(manager, false, Collections.emptyMap(), canon, Collections.emptyMap(), 10000);
     }
 
     @After
@@ -73,6 +73,7 @@ public class WebappTest {
             assertTrue(response.contains("20060614070159"));
             Document xml = parseXml(response);
             assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
+            assertEquals("2", xpath(xml, "/wayback/request/numresults").getTextContent());
         }
 
         POST("/test", "@alias http://example.com/ http://www.nla.gov.au/\n- 20100614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20100614070144-00003-crawling016.archive.org\n");
@@ -84,6 +85,7 @@ public class WebappTest {
             assertTrue(response.contains("20030614070159"));
             Document xml = parseXml(response);
             assertEquals("5", xpath(xml, "/wayback/request/numreturned").getTextContent());
+            assertEquals("5", xpath(xml, "/wayback/request/numresults").getTextContent());
         }
 
         {
@@ -91,6 +93,7 @@ public class WebappTest {
             assertEquals(2, StringUtils.countMatches(response, "<result>"));
             Document xml = parseXml(response);
             assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
+            assertEquals("5", xpath(xml, "/wayback/request/numresults").getTextContent());
         }
 
         {
@@ -99,6 +102,7 @@ public class WebappTest {
             assertTrue(response.contains("20050614070159"));
             Document xml = parseXml(response);
             assertEquals("3", xpath(xml, "/wayback/request/numreturned").getTextContent());
+            assertEquals("5", xpath(xml, "/wayback/request/numresults").getTextContent());
         }
 
         {
@@ -107,6 +111,7 @@ public class WebappTest {
             assertFalse(response.contains("20050614070159"));
             Document xml = parseXml(response);
             assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
+            assertEquals("5", xpath(xml, "/wayback/request/numresults").getTextContent());
         }
 
         POST("/test", "- 20060614070159 http://nla.gov.au/bad-wolf text/html bad-wolf XKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20050614070144-00003-crawling016.archive.org\n- 20040614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20060614070144-00003-crawling016.archive.org\n", BAD_REQUEST);

--- a/test/outbackcdx/WebappTest.java
+++ b/test/outbackcdx/WebappTest.java
@@ -6,10 +6,18 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import outbackcdx.UrlCanonicalizer.ConfigurationException;
 import outbackcdx.auth.Permit;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.*;
@@ -18,9 +26,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static outbackcdx.Json.GSON;
 import static outbackcdx.NanoHTTPD.Method.*;
-import static outbackcdx.NanoHTTPD.Response.Status.BAD_REQUEST;
-import static outbackcdx.NanoHTTPD.Response.Status.CREATED;
-import static outbackcdx.NanoHTTPD.Response.Status.OK;
+import static outbackcdx.NanoHTTPD.Response.Status.*;
 
 public class WebappTest {
     @Rule
@@ -56,15 +62,17 @@ public class WebappTest {
         POST("/test", "- 20060614070159 http://nla.gov.au/ text/html 200 XKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20050614070144-00003-crawling016.archive.org\n- 20040614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20060614070144-00003-crawling016.archive.org\n");
         {
             String response = GET("/test", "url", "nla.gov.au");
-            assertTrue(response.indexOf("au,gov,nla)/ 20050614070159") != -1);
-            assertTrue(response.indexOf("example") == -1);
+            assertTrue(response.contains("au,gov,nla)/ 20050614070159"));
+            assertTrue(!response.contains("example"));
         }
 
 
         {
             String response = GET("/test", "q", "type:urlquery url:http%3A%2F%2Fnla.gov.au%2F");
-            assertTrue(response.indexOf("20050614070159") != -1);
-            assertTrue(response.indexOf("20060614070159") != -1);
+            assertTrue(response.contains("20050614070159"));
+            assertTrue(response.contains("20060614070159"));
+            Document xml = parseXml(response);
+            assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
         }
 
         POST("/test", "@alias http://example.com/ http://www.nla.gov.au/\n- 20100614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20100614070144-00003-crawling016.archive.org\n");
@@ -74,27 +82,43 @@ public class WebappTest {
             assertTrue(response.contains("20060614070159"));
             assertTrue(response.contains("20100614070159"));
             assertTrue(response.contains("20030614070159"));
+            Document xml = parseXml(response);
+            assertEquals("5", xpath(xml, "/wayback/request/numreturned").getTextContent());
         }
 
         {
             String response = GET("/test", "q", "type:urlquery url:http%3A%2F%2Fnla.gov.au%2F limit:2 offset:0");
             assertEquals(2, StringUtils.countMatches(response, "<result>"));
+            Document xml = parseXml(response);
+            assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
         }
 
         {
             String response = GET("/test", "q", "type:urlquery url:http%3A%2F%2Fnla.gov.au%2F", "count", "3", "start_page", "1");
             assertEquals(3, StringUtils.countMatches(response, "<result>"));
             assertTrue(response.contains("20050614070159"));
+            Document xml = parseXml(response);
+            assertEquals("3", xpath(xml, "/wayback/request/numreturned").getTextContent());
         }
 
         {
             String response = GET("/test", "q", "type:urlquery url:http%3A%2F%2Fnla.gov.au%2F", "count", "3", "start_page", "2");
             assertEquals(2, StringUtils.countMatches(response, "<result>"));
             assertFalse(response.contains("20050614070159"));
+            Document xml = parseXml(response);
+            assertEquals("2", xpath(xml, "/wayback/request/numreturned").getTextContent());
         }
 
         POST("/test", "- 20060614070159 http://nla.gov.au/bad-wolf text/html bad-wolf XKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20050614070144-00003-crawling016.archive.org\n- 20040614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20060614070144-00003-crawling016.archive.org\n", BAD_REQUEST);
         POST("/test", "- 20060614070159 http://nla.gov.au/bad-wolf text/html bad-wolf XKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20050614070144-00003-crawling016.archive.org\n- 20040614070159 http://example.com/ text/html 200 AKMCCEPOOWFMGGO5635HFZXGFRLRGWIX - - - 337023 NLA-AU-CRAWL-000-20060614070144-00003-crawling016.archive.org\n", OK, "badLines", "skip");
+    }
+
+    private static Node xpath(Document doc, String expr) throws XPathExpressionException {
+        return (Node) XPathFactory.newInstance().newXPath().compile(expr).evaluate(doc, XPathConstants.NODE);
+    }
+
+    private static Document parseXml(String xml) throws SAXException, IOException, ParserConfigurationException {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
     }
 
     @Test


### PR DESCRIPTION
We maintain the ability to stream results by moving `<request>` after `<results>`. This change seems to be compatible with both OpenWayback and Pywb. I couldn't find any other clients using the XML protocol to check.

In order to prevent runaway slow queries a new `--max-num-results` limit is added. This limits the number of extra records that will be scanned when calculating the numresults statistic as a safety measure to prevent queries that were fine before this change suddenly becoming much slower. It does not actually limit the actual results returned though so clients can still stream larger result sets than this limit if they request them. In future it might be nice to make this a per-request option.

Closes #97. CC @kris-sigur.

