### PR TITLE
Account for the possibility that compressed size is not available

### DIFF
--- a/src/outbackcdx/Capture.java
+++ b/src/outbackcdx/Capture.java
@@ -53,7 +53,7 @@ public class Capture {
     public String mimetype;
     public int status;
     public String digest;
-    public long length;
+    public long length = -1;
     public String file;
     public long compressedoffset;
     public String redirecturl;
@@ -334,7 +334,7 @@ public class Capture {
         out.append(digest).append(" ");
         out.append(redirecturl).append(" ");
         out.append(robotflags).append(" ");
-        out.append(Long.toString(length)).append(" ");
+        out.append((length == -1) ? "-" : length).append(" ");
         out.append(compressedoffset).append(" ");
         out.append(file);
 
@@ -393,7 +393,7 @@ public class Capture {
 
         if (fields.length >= 11) { // 11 fields: CDX N b a m s k r M S V g
             capture.robotflags = fields[7];
-            capture.length = fields[8].equals("-") ? 0 : Long.parseLong(fields[8]);
+            capture.length = fields[8].equals("-") ? -1 : Long.parseLong(fields[8]);
             capture.compressedoffset = Long.parseLong(fields[9]);
             capture.file = fields[10];
 
@@ -478,7 +478,7 @@ public class Capture {
             case "robotflags":
                 return robotflags;
             case "length":
-                return length;
+                return (length == -1) ? "-" : length;
             case "offset":
                 return compressedoffset;
             case "filename":
@@ -490,7 +490,11 @@ public class Capture {
             case "originalFilename":
                 return originalFile;
             case "range":
-                return "bytes=" + compressedoffset + "-" + (compressedoffset + length - 1);
+                if (length == -1) {
+                    return "bytes=" + compressedoffset + "-";
+                } else {
+                    return "bytes=" + compressedoffset + "-" + (compressedoffset + length - 1);
+                }
             default:
                 throw new IllegalArgumentException("no such capture field: " + field);
         }

--- a/src/outbackcdx/VarInt.java
+++ b/src/outbackcdx/VarInt.java
@@ -59,7 +59,7 @@ public class VarInt {
 
     public static int size(long x) {
         int size = 1;
-        while (x > 127) {
+        while (Long.compareUnsigned(x, 127) > 0) {
             size++;
             x >>>= 7;
         }
@@ -67,7 +67,7 @@ public class VarInt {
     }
 
     public static void encode(ByteBuffer bb, long x) {
-        while (x > 127) {
+        while (Long.compareUnsigned(x, 127) > 0) {
             bb.put((byte) (x & 127 | 128));
             x >>>= 7;
         }

--- a/src/outbackcdx/XmlQuery.java
+++ b/src/outbackcdx/XmlQuery.java
@@ -140,7 +140,9 @@ public class XmlQuery {
             }
             out.writeStartElement("result");
             writeElement(out, "compressedoffset", capture.compressedoffset);
-            writeElement(out, "compressedendoffset", capture.length);
+            if (capture.length != -1) {
+                writeElement(out, "compressedendoffset", capture.length);
+            }
             writeElement(out, "mimetype", capture.mimetype);
             writeElement(out, "file", capture.file);
             writeElement(out, "redirecturl", capture.redirecturl);

--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -25,6 +25,16 @@ public class CaptureTest {
     }
 
     @Test
+    public void testCdx9() {
+        Capture src = Capture.fromCdxLine("- 19870102030405 http://example.org/ text/html 200 M5ORM4XQ5QCEZEDRNZRGSWXPCOGUVASI - 100 test.warc.gz", new UrlCanonicalizer());
+        Capture dst = new Capture(src.encodeKey(), src.encodeValue());
+        assertEquals(-1, src.length);
+        assertEquals(100, src.compressedoffset);
+        assertFieldsEqual(src, dst);
+        assertEquals("org,example)/ 19870102030405 http://example.org/ text/html 200 M5ORM4XQ5QCEZEDRNZRGSWXPCOGUVASI - - - 100 test.warc.gz - - -", dst.toString());
+    }
+
+    @Test
     public void testV4Encoding() {
         Capture src = dummyRecord();
         byte[] key = src.encodeKey(4);

--- a/test/outbackcdx/VarIntTest.java
+++ b/test/outbackcdx/VarIntTest.java
@@ -9,7 +9,15 @@ import static org.junit.Assert.assertEquals;
 public class VarIntTest {
     @Test
     public void testVarIntRoundTrip() {
-        long testValue = 632662171617822L;
+        roundTrip(632662171617822L);
+        roundTrip(0);
+        roundTrip(-1);
+        roundTrip(-42);
+        roundTrip(Long.MIN_VALUE);
+        roundTrip(Long.MAX_VALUE);
+    }
+
+    private void roundTrip(long testValue) {
         ByteBuffer bb = ByteBuffer.allocate(32);
         VarInt.encode(bb, testValue);
         assertEquals(VarInt.size(testValue), bb.position());


### PR DESCRIPTION
Set Capture.length to -1 when value is unavailable (to differentiate from the - unlikely - case of an empty file in the index). Adjust query responses to use a dash rather than a a zero when it isn't present.

We also fix VarInt's encoding of negative longs by using an unsigned comparison.

CC: @kris-sigur 