### PR TITLE
Pywb-style CDXJ input and output formats

### DIFF
--- a/src/outbackcdx/HmacField.java
+++ b/src/outbackcdx/HmacField.java
@@ -136,7 +136,8 @@ public class HmacField implements ComputedField {
                     value = "\r\n";
                     break;
                 default:
-                    value = capture.get(variable).toString();
+                    Object obj = capture.get(variable);
+                    value = obj == null ? "-" : obj.toString();
                     break;
             }
             matcher.appendReplacement(buffer, value);

--- a/src/outbackcdx/Query.java
+++ b/src/outbackcdx/Query.java
@@ -3,7 +3,7 @@ package outbackcdx;
 import java.util.function.Predicate;
 
 public class Query {
-    private static final String DEFAULT_FIELDS = "urlkey,timestamp,original,mimetype,statuscode,digest,redirecturl,robotflags,length,offset,filename";
+    private static final String DEFAULT_FIELDS = "urlkey,timestamp,url,mime,status,digest,redirecturl,robotflags,length,offset,filename";
     private static final String DEFAULT_FIELDS_CDX14 = DEFAULT_FIELDS + ",originalLength,originalOffset,originalFilename";
 
     public static final long MIN_TIMESTAMP = 0l;

--- a/test/outbackcdx/CaptureTest.java
+++ b/test/outbackcdx/CaptureTest.java
@@ -35,6 +35,16 @@ public class CaptureTest {
     }
 
     @Test
+    public void testCdxj() {
+        Capture src = Capture.fromCdxLine("com,example)/robots.txt 20210203115119 {\"url\": \"https://example.org/robots.txt\", \"mime\": \"unk\", \"status\": \"400\", \"digest\": \"3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ\", \"length\": \"451\", \"offset\": \"90493\", \"filename\": \"example.warc.gz\"}", new UrlCanonicalizer());
+        Capture dst = new Capture(src.encodeKey(), src.encodeValue());
+        assertEquals(451, src.length);
+        assertEquals(90493, src.compressedoffset);
+        assertFieldsEqual(src, dst);
+        assertEquals("com,example)/robots.txt 20210203115119 https://example.org/robots.txt unk 400 3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ - - 451 90493 example.warc.gz - - -", dst.toString());
+    }
+
+    @Test
     public void testV4Encoding() {
         Capture src = dummyRecord();
         byte[] key = src.encodeKey(4);

--- a/test/outbackcdx/WbCdxApiTest.java
+++ b/test/outbackcdx/WbCdxApiTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+
 public class WbCdxApiTest {
     @Test
     public void hostFromSurt() {
@@ -40,5 +44,14 @@ public class WbCdxApiTest {
         query.expandWildcards();
         assertEquals(Query.MatchType.EXACT, query.matchType);
         assertEquals("http://example.org/*", query.url);
+    }
+
+    @Test
+    public void testCdxjOutputFormat() throws IOException {
+        Query query = new Query(new MultiMap<>(), Collections.emptyList());
+        StringWriter sw = new StringWriter();
+        Capture capture = Capture.fromCdxLine("- 19870102030405 http://example.org/ text/html 200 M5ORM4XQ5QCEZEDRNZRGSWXPCOGUVASI - 100 test.warc.gz", new UrlCanonicalizer());
+        new WbCdxApi.CdxjFormat(query, Collections.emptyMap(), sw).writeCapture(capture);
+        assertEquals("org,example)/ 19870102030405 {\"url\":\"http://example.org/\",\"mime\":\"text/html\",\"status\":\"200\",\"digest\":\"M5ORM4XQ5QCEZEDRNZRGSWXPCOGUVASI\",\"offset\":\"100\",\"filename\":\"test.warc.gz\"}\n", sw.toString());
     }
 }


### PR DESCRIPTION
This adds support for Pywb's CDXJ format. We follow the Pywb convention of emitting numeric values as JSON strings but accept JSON numbers if given them as input.

Support for arbitrarily named extension fields is not included yet and will be added separately as it requires a new version of the index storage format. Similarly our current index version doesn't really support the notion of missing fields so we map missing fields to "-" or -1 as appropriate for storage, which is a bit hacky but should generally work for now.

Other proposed CDXJ variants (such as "OpenWayback CDXJ") are not supported.

CC @ikreymer @anjackson
Closes #48